### PR TITLE
Make searching interval consistent

### DIFF
--- a/main.py
+++ b/main.py
@@ -169,7 +169,7 @@ async def init_main():
             break
         except:
             print("Searching for an open Spotify.exe process...")
-            await asyncio.sleep(3)
+            await asyncio.sleep(5)
 
     splash()
 


### PR DESCRIPTION
Search for the Spotify.exe process every 5 seconds in all cases, rather than 5 seconds or 3 seconds like it was before.